### PR TITLE
more init options

### DIFF
--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -73,16 +73,17 @@ struct ContentView: View {
     @State var isPresented: Bool = false
     @State var currentIndex: Int = 1
     var mediaItems: [SwipingMediaItem] = []
-
+    
     init() {
         self.mediaItems =  [SwipingMediaItem(url: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4",
                                              type: .video),
                             SwipingMediaItem(url: "https://i.redd.it/8t6vk567khm91.jpg",
-                                             type: .image),
+                                             type: .image, 
+                                             shouldShowDownloadButton: true),
                             SwipingMediaItem(url: "https://i.redd.it/gczavw14bfm91.gif",
                                              type: .gif)]
     }
-
+    
     var body: some View {
         ZStack {
             Color.green
@@ -98,10 +99,15 @@ struct ContentView: View {
         // FullScreenCover works well in presenting SwipingMediaView
         .fullScreenCover(isPresented: $isPresented) {
             ZStack{
-                SwipingMediaView(controllers: mediaItems.map {AnyView(SwipingMediaItemView(mediaItem: $0,
-                                                                                           isPresented: $isPresented,
-                                                                                           shouldShowDownloadButton: true
-                                                                                          ))},
+//                SwipingMediaView(views: mediaItems.map {SwipingMediaItemView(mediaItem: $0,
+//                                                                            isPresented: $isPresented,
+//                                                                            shouldShowDownloadButton: true
+//                )},
+//                                 currentIndex: $currentIndex,
+//                                 startingIndex: currentIndex)
+                
+                SwipingMediaView(mediaItems: mediaItems,
+                                 isPresented: $isPresented,
                                  currentIndex: $currentIndex,
                                  startingIndex: currentIndex)
             }


### PR DESCRIPTION
- BREAKING CHANGE: 
shouldDownloadButton is no longer handle by SwipingMediaItemView, instead it is now handled by SwipingMediaItem
```swift
self.mediaItems =  [SwipingMediaItem(url: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4",
                                             type: .video),
                            SwipingMediaItem(url: "https://i.redd.it/8t6vk567khm91.jpg",
                                             type: .image, 
                                             shouldShowDownloadButton: true),
                            SwipingMediaItem(url: "https://i.redd.it/gczavw14bfm91.gif",
                                             type: .gif)]
```

- Deprecated init with controllers
- new init option to init with SwiftUI views without having to cast to AnyView
```swift
                SwipingMediaView(views: mediaItems.map {SwipingMediaItemView(mediaItem: $0,
                                                                            isPresented: $isPresented,
                                                                            shouldShowDownloadButton: true
                )},
                                 currentIndex: $currentIndex,
                                 startingIndex: currentIndex)
```
- new init option to init with just SwipingMediaItem
```swift
      SwipingMediaView(mediaItems: mediaItems,
                                 isPresented: $isPresented,
                                 currentIndex: $currentIndex,
                                 startingIndex: currentIndex)
```
